### PR TITLE
Fix bug with nova charts

### DIFF
--- a/app/Models/Stats/StatBuffer.php
+++ b/app/Models/Stats/StatBuffer.php
@@ -28,7 +28,7 @@ class StatBuffer extends Model
         return $this->morphTo('target');
     }
 
-    public static function queryBufferAsArray($min, $max, $order = 'desc')
+    public static function queryBufferAsArray($min, $max, $order = 'asc')
     {
         $range = match ($order) {
             'asc' => range($min, $max),
@@ -44,7 +44,7 @@ class StatBuffer extends Model
         return DB::raw($dailyValues);
     }
 
-    public function scopeBuffers($query, $startingDate, $endDate = null, $order = 'desc')
+    public function scopeBuffers($query, $startingDate, $endDate = null, $order = 'asc')
     {
         return $query
             ->whereBetween('created_at', [$startingDate, $endDate ?? now()])

--- a/app/Nova/Metrics/PerDay.php
+++ b/app/Nova/Metrics/PerDay.php
@@ -80,12 +80,14 @@ class PerDay extends Trend
 
     public function calculate(NovaRequest $request)
     {
+        $dayOfWeek = now()->dayOfWeek + 1;
+        $offset = 7 - $dayOfWeek;
         $startingDate = $this->getAggregateStartingDate($request, self::BY_DAYS);
 
         $query = static::queryStatBuffer(
             relation: $this->relation(),
             event: $this->event?->value ?? 'view',
-            startingDate: $startingDate,
+            startingDate: $startingDate->subDays($offset),
             trigger: $this->trigger,
             user: Auth::user()
         );
@@ -94,6 +96,8 @@ class PerDay extends Trend
             fn ($c, $v) => array_merge($c, $v->buffer),
             []
         );
+        
+        $buffer = array_slice($buffer, $dayOfWeek, -$offset);
 
         $trend = [];
         $total = 0;
@@ -134,6 +138,7 @@ class PerDay extends Trend
      */
     public function cacheFor()
     {
+        return now();
         return now()->addMinutes(config('app-analytics.cache'));
     }
 

--- a/app/Nova/Metrics/PerDay.php
+++ b/app/Nova/Metrics/PerDay.php
@@ -96,7 +96,7 @@ class PerDay extends Trend
             fn ($c, $v) => array_merge($c, $v->buffer),
             []
         );
-        
+
         $buffer = array_slice($buffer, $dayOfWeek, -$offset);
 
         $trend = [];
@@ -139,6 +139,7 @@ class PerDay extends Trend
     public function cacheFor()
     {
         return now();
+
         return now()->addMinutes(config('app-analytics.cache'));
     }
 

--- a/app/Nova/Metrics/PerDayPerResource.php
+++ b/app/Nova/Metrics/PerDayPerResource.php
@@ -77,12 +77,14 @@ class PerDayPerResource extends Trend
     public function calculate(NovaRequest $request)
     {
         $resource = $request->findResourceOrFail();
+        $dayOfWeek = now()->dayOfWeek + 1;
+        $offset = 7 - $dayOfWeek;
         $startingDate = $this->getAggregateStartingDate($request, self::BY_DAYS);
 
         $query = static::queryStatBuffer(
             resource: $resource,
             event: $this->event?->value ?? 'view',
-            startingDate: $startingDate,
+            startingDate: $startingDate->subDays($offset),
             trigger: $this->trigger
         );
 
@@ -91,6 +93,8 @@ class PerDayPerResource extends Trend
             []
         );
 
+        $buffer = array_slice($buffer, $dayOfWeek, -$offset);
+        
         $trend = [];
         $total = 0;
 
@@ -130,6 +134,7 @@ class PerDayPerResource extends Trend
      */
     public function cacheFor()
     {
+        return now();
         return now()->addHours(config('app-analytics.cache'));
     }
 

--- a/app/Nova/Metrics/PerDayPerResource.php
+++ b/app/Nova/Metrics/PerDayPerResource.php
@@ -94,7 +94,7 @@ class PerDayPerResource extends Trend
         );
 
         $buffer = array_slice($buffer, $dayOfWeek, -$offset);
-        
+
         $trend = [];
         $total = 0;
 
@@ -135,6 +135,7 @@ class PerDayPerResource extends Trend
     public function cacheFor()
     {
         return now();
+
         return now()->addHours(config('app-analytics.cache'));
     }
 


### PR DESCRIPTION
nova charts were displaying a gap in the views because the days were being queried backwards and did not properly offset the array